### PR TITLE
Added .npmrc file.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Added a ".npmrc" file with `legacy-peer-deps=true`, so I can remove `--legacy-peer-deps` from my Amplify build setting.